### PR TITLE
Fix IPv6 length check

### DIFF
--- a/iocextract.py
+++ b/iocextract.py
@@ -630,7 +630,7 @@ def extract_ipv6s(data):
 
     for ip_address in IPV6_RE.finditer(data):
         # Sets a minimal standard for IPv6 (0:0:0:0:0:0:0:0)
-        if len(data) >= 15:
+        if len(ip_address.group(0)) >= 15:
             yield ip_address.group(0)
 
 


### PR DESCRIPTION
This PR fixes the minimum length check for extracted IPv6 addresses.

The current implementation is checking the length of the the data (input string) that IPs were extracted from, not the extracted IP address. This is causing `extract_ipv6s()` to extract time values:

## Before

```py3
>>> from iocextract import extract_ipv6s
>>> list(extract_ipv6s("Today is 2024-07-18 and it is currently 23:06:41 UTC"))
['23:06:41']
>>>
```

## After

```py3
>>> from iocextract import extract_ipv6s
>>> list(extract_ipv6s("Today is 2024-07-18 and it is currently 23:06:41 UTC"))
[]
>>> 
```

## :mag: References
- cc 2d84737
- Closes #79 