### PR TITLE
Add backtick to `END_PUNCTUATION` regex

### DIFF
--- a/iocextract.py
+++ b/iocextract.py
@@ -35,7 +35,7 @@ except ImportError:
     from urllib import unquote
 
 # Reusable end punctuation regex
-END_PUNCTUATION = r"[\.\?>\"'\)!,}:;\u201d\u2019\uff1e\uff1c\]]*"
+END_PUNCTUATION = r"[\.\?>\"'`\)!,}:;\u201d\u2019\uff1e\uff1c\]]*"
 
 # Reusable regex for symbols commonly used to defang
 SEPARATOR_DEFANGS = r"[\(\)\[\]{}<>\\]"

--- a/tests.py
+++ b/tests.py
@@ -631,7 +631,7 @@ class TestExtractors(unittest.TestCase):
         """
         Any url ending with a punctuation character defined in `END_PUNCTUATION` should be extracted without the punctuation.
         """
-        end_punctuation = ['.', '?', '>', '"', '\'', ')', '!', ',', '}', ':', ';', '\u201d', '\u2019', '\uff1e', '\uff1c', ']']
+        end_punctuation = ['.', '?', '>', '"', '\'', '`', ')', '!', ',', '}', ':', ';', '\u201d', '\u2019', '\uff1e', '\uff1c', ']']
         unicode_end = ['\u201d', '\u2019', '\uff1e', '\uff1c']
 
         # extracted url should not end with the punctuation

--- a/tests.py
+++ b/tests.py
@@ -627,6 +627,25 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(list(iocextract.extract_urls('example[.]com/)'))[0], 'example[.]com/')
         self.assertEqual(list(iocextract.extract_urls('example[.]com/\''))[0], 'example[.]com/')
 
+    def test_url_extraction_end_punctuation(self):
+        """
+        Any url ending with a punctuation character defined in `END_PUNCTUATION` should be extracted without the punctuation.
+        """
+        end_punctuation = ['.', '?', '>', '"', '\'', ')', '!', ',', '}', ':', ';', '\u201d', '\u2019', '\uff1e', '\uff1c', ']']
+        unicode_end = ['\u201d', '\u2019', '\uff1e', '\uff1c']
+
+        # extracted url should not end with the punctuation
+        for end in end_punctuation:
+            self.assertEqual(list(iocextract.extract_urls('https://example.com' + end))[0], 'https://example.com')
+
+        # extracted url should still contain the punctuation if it is mid-url
+        for end in end_punctuation:
+            # skip unicode punctuation
+            if end in unicode_end:
+                continue
+
+            self.assertEqual(list(iocextract.extract_urls('https://example.com/a' + end + 'b'))[0], 'https://example.com/a' + end + 'b')
+
     def test_hex_url_extraction(self):
         if sys.version_info[0] == 3:
             hexconvert = lambda x: str(binascii.hexlify(bytes(x, 'ascii')), 'ascii')


### PR DESCRIPTION
This PR adds the backtick (`` ` ``) to the `END_PUNCTUATION` regex so that urls (and emails) surrounded in backticks are extracted properly. This will improve extraction from markdown documents where [backticks are used for inline code blocks](https://github.github.com/gfm/#code-spans).

It also adds a basic test to ensure this is working as expected for urls; I did not add a test for emails.

## Before

```py3
>>> from iocextract import extract_urls
>>> list(extract_urls('foo `https://example.com` bar'))
['https://example.com`']  # BAD: has a trailing backtick
>>>
>>> from iocextract import extract_emails
>>> list(extract_emails('foo `user@example.com` bar'))
[]  # BAD: email address not found
>>> 
```

## After

```py3
>>> from iocextract import extract_urls
>>> list(extract_urls('foo `https://example.com` bar'))
['https://example.com']  # GOOD: no trailing backtick
>>>
>>> from iocextract import extract_emails
>>> list(extract_emails('foo `user@example.com` bar'))
['user@example.com']  # GOOD: email extracted with no trailing backtick
>>>
```

> [!NOTE]
> While `` https://example.com/` `` _is_ a valid url it _should be_ encoded (`https://example.com/%60`). At the moment other valid urls like `https://example.com/"`, `https://example.com/}`, etc. are being extracted without trailing punctuation so I don't think deviates substantially from what is/isn't being extracted today.

## :mag: References

- cc https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding